### PR TITLE
VESC firmware 5 compatibility

### DIFF
--- a/vesc_comm_standard.cpp
+++ b/vesc_comm_standard.cpp
@@ -20,7 +20,7 @@
 #include "vesc_comm_standard.h"
 
 VescCommStandard::VescCommStandard() {
-    _max_packet_length = 70;
+    _max_packet_length = 78;
     _packet = (uint8_t*) malloc(_max_packet_length * sizeof(*_packet));
 }
 


### PR DESCRIPTION
This is the only change needed to have compatibility with VESC firmware 5 (tested on F5.01) I think. Now my cheap focer 2 that doesn't run older firmwares, works with the OS davega 